### PR TITLE
Add autoload cookie for the main function

### DIFF
--- a/side-notes.el
+++ b/side-notes.el
@@ -100,6 +100,7 @@ Return nil if no notes file found."
   (expand-file-name
    side-notes-file (locate-dominating-file default-directory side-notes-file)))
 
+;;;###autoload
 (defun side-notes-toggle-notes ()
   "Pop up a side window containing the notes file.
 


### PR DESCRIPTION
With autoload the loading of the library can be avoided in the config file.
"The first call to
the function automatically loads the proper library, in order to install
the real definition and other associated code, then runs the real
definition as if it had been loaded all along." (info "(elisp) Autoload")